### PR TITLE
Allow a custom fetch function to be provided in props

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ class SearchPage extends React.Component {
 | onReverseSelected | function | | | Invoked after reverse geocoding is performed. |
 | getSuggestionValue | function | ✓ | Identity Function | See https://github.com/moroshko/react-autosuggest#getsuggestionvalue-required for details. |
 | renderSuggestion | function | ✓ | Div Wrapper Function | See https://github.com/moroshko/react-autosuggest#rendersuggestion-required for details. |
+| fetch | function | | `fetch` (from `node-fetch`) | Make the HTTP requests with this custom function
 
 ## Ref Methods
 

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -20,7 +20,9 @@ export class ReactAutosuggestGeocoder extends React.Component {
     onSuggestionSelected: React.PropTypes.func,
     onReverseSelected: React.PropTypes.func,
     getSuggestionValue: React.PropTypes.func.isRequired,
-    renderSuggestion: React.PropTypes.func.isRequired
+    renderSuggestion: React.PropTypes.func.isRequired,
+
+    fetch: React.PropTypes.func
   };
 
   static defaultProps = {
@@ -37,7 +39,9 @@ export class ReactAutosuggestGeocoder extends React.Component {
       <div className='autosuggest-item'>
         {suggestion.properties.label}
       </div>
-    )
+    ),
+
+    fetch: fetch
   };
 
   constructor (props) {
@@ -91,7 +95,7 @@ export class ReactAutosuggestGeocoder extends React.Component {
       layers: 'address',
       size: 1
     });
-    return fetch(url + '?' + stringify(data), {
+    return this.props.fetch(url + '?' + stringify(data), {
       method: 'get',
       headers: {
         'Accept': 'application/json'
@@ -110,7 +114,7 @@ export class ReactAutosuggestGeocoder extends React.Component {
     }, {
       text: text
     });
-    return fetch(url + '?' + stringify(data), {
+    return this.props.fetch(url + '?' + stringify(data), {
       method: 'get',
       headers: {
         'Accept': 'application/json'
@@ -129,7 +133,7 @@ export class ReactAutosuggestGeocoder extends React.Component {
     }, {
       text: text
     });
-    return fetch(url + '?' + stringify(data), {
+    return this.props.fetch(url + '?' + stringify(data), {
       method: 'get',
       headers: {
         'Accept': 'application/json'


### PR DESCRIPTION
I considered how to best customize the API requests and figured that allowing a custom fetch function would be the most flexible and clean way.

If this new prop isn't present, the library will continue to function as before.

For example, it becomes easy to modify the URL parameters:

```javascript
  <ReactAutosuggestGeocoder
    fetch={(resource, options) => {
      return fetch(resource + "&key=value", options);
    }
    // ...
  />
```